### PR TITLE
disable gpgcheck by default for hhvm package

### DIFF
--- a/templates/amazon/yum/opsrock-hhvm.repo.erb
+++ b/templates/amazon/yum/opsrock-hhvm.repo.erb
@@ -2,7 +2,7 @@
 name=Opsrock hhvm for Amazon Linux Repository
 baseurl=https://packagecloud.io/opsrock-hhvm/hhvm-test/el/6/$basearch
 enabled=1
-gpgcheck=1
+gpgcheck=0
 gpgkey=https://packagecloud.io/gpg.key
 includepkgs=hhvm
 sslverify=true


### PR DESCRIPTION
hhvmのパッケージ、しばらく署名する気もないのでgpgcheck無効にします。
