### PR TITLE
use stable for hhvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Gemfile.lock
 .kitchen/
 .kitchen.local.yml
+/.envrc

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,16 +2,19 @@
 driver_plugin: ec2
 driver_config:
   require_chef_omnibus: latest
-  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY'] %>
-  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   aws_ssh_key_id: <%= ENV['AWS_EC2_KEYPAIR'] %>
+#  aws_access_key_id: <%= ENV['AWS_ACCESS_KEY'] %>              #autoload from ENV:AWS_ACCESS_KEY
+#  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>   #autoload from ENV:AWS_SECRET_ACCESS_KEY
+
+transport:
   ssh_key: <%= ENV['AWS_EC2_KEYPASS'] %>
+  username: ec2-user
+
 
 platforms:
 - name: amazon-linux-micro-tokyo
   driver_config:
-    username: ec2-user
-    flavor_id: t1.micro
+    instance_type: t1.micro
     image_id: ami-c7f90ec7 # Amazon Linux AMI 2015.03.0 (HVM)
     region: ap-northeast-1
     availability_zone: ap-northeast-1a
@@ -19,8 +22,7 @@ platforms:
       Name: test-kitchen-micro
 - name: amazon-linux-large-tokyo
   driver_config:
-    username: ec2-user
-    flavor_id: c3.large
+    instance_type: c3.large
     image_id: ami-c7f90ec7 # Amazon Linux AMI 2015.03.0 (HVM)
     region: ap-northeast-1
     availability_zone: ap-northeast-1a
@@ -28,8 +30,7 @@ platforms:
       Name: test-kitchen-large
 - name: rhel64-micro-tokyo
   driver_config:
-    username: ec2-user
-    flavor_id: t1.micro
+    instance_type: t1.micro
     image_id: ami-5769f956  # Red Hat Enterprise Linux 6.4
     region: ap-northeast-1
     availability_zone: ap-northeast-1a

--- a/recipes/hhvm.rb
+++ b/recipes/hhvm.rb
@@ -1,4 +1,6 @@
-# php54 install
+# php install
+
+node.override[:php][:packages] = node[:php][:packages] - %w{ php-opcache }
 
 include_recipe 'amimoto::php'
 

--- a/templates/amazon/yum/opsrock-hhvm.repo.erb
+++ b/templates/amazon/yum/opsrock-hhvm.repo.erb
@@ -1,6 +1,6 @@
 [opsrock-hhvm]
 name=Opsrock hhvm for Amazon Linux Repository
-baseurl=https://packagecloud.io/opsrock-hhvm/hhvm-test/el/6/$basearch
+baseurl=https://packagecloud.io/opsrock-hhvm/hhvm-stable/el/6/$basearch
 enabled=1
 gpgcheck=0
 gpgkey=https://packagecloud.io/gpg.key


### PR DESCRIPTION
hhvmのパッケージ置き場が、ずっとtestでした。。。 stableに変更しておく方が無難です。
