### PR TITLE
initial install mu-plugins for cloudformation stack

### DIFF
--- a/initial.wp-setup-hhvm.sh
+++ b/initial.wp-setup-hhvm.sh
@@ -191,6 +191,12 @@ if [ "$CF_PATTERN" != "nfs_client" ]; then
   if [ -d /tmp/amimoto/mu-plugins ]; then
     /bin/cp -rf /tmp/amimoto/mu-plugins/* $MU_PLUGINS
   fi
+  if [ -f /tmp/amimoto/cf_option_check.php ]; then
+    CF_OPTION=`/usr/bin/php /tmp/amimoto/cf_option_check.php`
+    if [ "$CF_OPTION" = "cloudfront" ]; then
+      /bin/cp -rf /tmp/amimoto/options/mu-plugins/* $MU_PLUGINS
+    fi
+  fi
 
   /bin/rm /var/www/vhosts/${INSTANCEID}/index.html
   /bin/chown -R nginx:nginx /var/cache/nginx

--- a/initial.wp-setup.sh
+++ b/initial.wp-setup.sh
@@ -229,6 +229,12 @@ if [ "$CF_PATTERN" != "nfs_client" ]; then
   if [ -d /tmp/amimoto/mu-plugins ]; then
     /bin/cp -rf /tmp/amimoto/mu-plugins/* $MU_PLUGINS
   fi
+  if [ -f /tmp/amimoto/cf_option_check.php ]; then
+    CF_OPTION=`/usr/bin/php /tmp/amimoto/cf_option_check.php`
+    if [ "$CF_OPTION" = "cloudfront" ]; then
+      /bin/cp -rf /tmp/amimoto/options/mu-plugins/* $MU_PLUGINS
+    fi
+  fi
 
   /bin/rm /var/www/vhosts/${INSTANCEID}/index.html
   /bin/chown -R nginx:nginx /var/cache/nginx


### PR DESCRIPTION
amimotoのリポジトリに「/tmp/amimoto/cf_option_check.php」を追加後から稼働開始、
CFNで立ち上げた場合にCloudFrontやEC2インスタンスロール対応用のmu-pluginを追加する。
