### PR TITLE
2016.01.add s3 repo as mirror

### DIFF
--- a/initial.wp-setup-hhvm.sh
+++ b/initial.wp-setup-hhvm.sh
@@ -61,8 +61,9 @@ if [ -f /etc/nginx/conf.d/default.backend.conf ]; then
   /bin/rm -f /etc/nginx/conf.d/default.backend.conf
 fi
 
-/usr/bin/git -C /opt/local/chef-repo/ pull origin master
-/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH}
+# /usr/bin/git -C /opt/local/chef-repo/ pull origin master
+/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH} || \
+  /usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull mirror ${AMIMOTO_BRANCH}
 /usr/bin/chef-solo -c /opt/local/solo.rb -j /opt/local/amimoto.json
 if [ ! -f /etc/nginx/nginx.conf ]; then
   /usr/bin/chef-solo -o amimoto::nginx -c /opt/local/solo.rb -j /opt/local/amimoto.json

--- a/initial.wp-setup-hhvm.sh
+++ b/initial.wp-setup-hhvm.sh
@@ -76,7 +76,7 @@ fi
 /usr/sbin/update-motd
 
 cd /tmp
-/usr/bin/git clone git://github.com/megumiteam/amimoto.git
+/usr/bin/git clone git://github.com/megumiteam/amimoto.git || /usr/bin/git clone http://repos.amimoto-ami.com/amimoto.git
 
 #CF_PATTERN=`/usr/bin/curl -s https://raw.githubusercontent.com/megumiteam/amimoto/master/cf_patern_check.php | /usr/bin/php`
 CF_PATTERN=`/usr/bin/php /tmp/amimoto/cf_patern_check.php`

--- a/initial.wp-setup-hhvm.sh
+++ b/initial.wp-setup-hhvm.sh
@@ -118,10 +118,10 @@ fi
 /sbin/service monit start
 
 WP_CLI=/usr/local/bin/wp
-if [ ! -f $WP_CLI ]; then
-  cd /usr/local/bin
-  /usr/bin/curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-  mv wp-cli.phar /usr/local/bin/wp
+cd /usr/local/bin
+/usr/bin/curl -fO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+if [ -f wp-cli.phar ] ; then
+  mv -f wp-cli.phar /usr/local/bin/wp
   chmod +x /usr/local/bin/wp
 fi
 

--- a/initial.wp-setup-http2.sh
+++ b/initial.wp-setup-http2.sh
@@ -79,7 +79,7 @@ fi
 /usr/sbin/update-motd
 
 cd /tmp
-/usr/bin/git clone git://github.com/megumiteam/amimoto.git
+/usr/bin/git clone git://github.com/megumiteam/amimoto.git || /usr/bin/git clone http://repos.amimoto-ami.com/amimoto.git
 
 #CF_PATTERN=`/usr/bin/curl -s https://raw.githubusercontent.com/megumiteam/amimoto/master/cf_patern_check.php | /usr/bin/php`
 CF_PATTERN=`/usr/bin/php /tmp/amimoto/cf_patern_check.php`

--- a/initial.wp-setup-http2.sh
+++ b/initial.wp-setup-http2.sh
@@ -121,10 +121,10 @@ fi
 /sbin/service monit start
 
 WP_CLI=/usr/local/bin/wp
-if [ ! -f $WP_CLI ]; then
-  cd /usr/local/bin
-  /usr/bin/curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-  mv wp-cli.phar /usr/local/bin/wp
+cd /usr/local/bin
+/usr/bin/curl -fO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+if [ -f wp-cli.phar ] ; then
+  mv -f wp-cli.phar /usr/local/bin/wp
   chmod +x /usr/local/bin/wp
 fi
 

--- a/initial.wp-setup-http2.sh
+++ b/initial.wp-setup-http2.sh
@@ -64,8 +64,9 @@ if [ -f /etc/nginx/conf.d/default.backend.conf ]; then
   /bin/rm -f /etc/nginx/conf.d/default.backend.conf
 fi
 
-/usr/bin/git -C /opt/local/chef-repo/ pull origin master
-/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH}
+# /usr/bin/git -C /opt/local/chef-repo/ pull origin master
+/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH} || \
+  /usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull mirror ${AMIMOTO_BRANCH}
 /usr/bin/chef-solo -c /opt/local/solo.rb -j /opt/local/amimoto.json
 if [ ! -f /etc/nginx/nginx.conf ]; then
   /usr/bin/chef-solo -o amimoto::nginx -c /opt/local/solo.rb -j /opt/local/amimoto.json

--- a/initial.wp-setup-mod-php-woo.sh
+++ b/initial.wp-setup-mod-php-woo.sh
@@ -102,7 +102,7 @@ fi
 /usr/sbin/update-motd
 
 cd /tmp
-/usr/bin/git clone git://github.com/megumiteam/amimoto.git
+/usr/bin/git clone git://github.com/megumiteam/amimoto.git || /usr/bin/git clone http://repos.amimoto-ami.com/amimoto.git
 
 #CF_PATTERN=`/usr/bin/curl -s https://raw.githubusercontent.com/megumiteam/amimoto/master/cf_patern_check.php | /usr/bin/php`
 CF_PATTERN=`/usr/bin/php /tmp/amimoto/cf_patern_check.php`
@@ -143,10 +143,10 @@ fi
 /sbin/service monit start
 
 WP_CLI=/usr/local/bin/wp
-if [ ! -f $WP_CLI ]; then
-  cd /usr/local/bin
-  /usr/bin/curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-  mv wp-cli.phar /usr/local/bin/wp
+cd /usr/local/bin
+/usr/bin/curl -fO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+if [ -f wp-cli.phar ] ; then
+  mv -f wp-cli.phar /usr/local/bin/wp
   chmod +x /usr/local/bin/wp
 fi
 

--- a/initial.wp-setup-mod-php-woo.sh
+++ b/initial.wp-setup-mod-php-woo.sh
@@ -85,8 +85,9 @@ if [ -f /etc/httpd/conf.d/wordpress.conf ]; then
   /bin/rm -f /etc/httpd/conf.d/mod_remoteip.conf
 fi
 
-/usr/bin/git -C /opt/local/chef-repo/ pull origin master
-/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH}
+# /usr/bin/git -C /opt/local/chef-repo/ pull origin master
+/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH} || \
+  /usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull mirror ${AMIMOTO_BRANCH}
 if [ ! -f /etc/httpd/conf/httpd.conf ]; then
   /usr/bin/chef-solo -o amimoto::httpd_default -c /opt/local/solo.rb -j /opt/local/amimoto.json
   /usr/bin/chef-solo -o amimoto::mod_php7 -c /opt/local/solo.rb -j /opt/local/amimoto.json

--- a/initial.wp-setup-mod_php.sh
+++ b/initial.wp-setup-mod_php.sh
@@ -70,8 +70,9 @@ if [ -f /etc/httpd/conf.d/wordpress.conf ]; then
   /bin/rm -f /etc/httpd/conf.d/mod_remoteip.conf
 fi
 
-/usr/bin/git -C /opt/local/chef-repo/ pull origin master
-/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH}
+# /usr/bin/git -C /opt/local/chef-repo/ pull origin master
+/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH} || \
+  /usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull mirror ${AMIMOTO_BRANCH}
 if [ ! -f /etc/httpd/conf/httpd.conf ]; then
   /usr/bin/chef-solo -o amimoto::httpd_default -c /opt/local/solo.rb -j /opt/local/amimoto.json
   /usr/bin/chef-solo -o amimoto::mod_php7 -c /opt/local/solo.rb -j /opt/local/amimoto.json

--- a/initial.wp-setup-mod_php.sh
+++ b/initial.wp-setup-mod_php.sh
@@ -87,7 +87,7 @@ fi
 /usr/sbin/update-motd
 
 cd /tmp
-/usr/bin/git clone git://github.com/megumiteam/amimoto.git
+/usr/bin/git clone git://github.com/megumiteam/amimoto.git || /usr/bin/git clone http://repos.amimoto-ami.com/amimoto.git
 
 #CF_PATTERN=`/usr/bin/curl -s https://raw.githubusercontent.com/megumiteam/amimoto/master/cf_patern_check.php | /usr/bin/php`
 CF_PATTERN=`/usr/bin/php /tmp/amimoto/cf_patern_check.php`
@@ -128,10 +128,10 @@ fi
 /sbin/service monit start
 
 WP_CLI=/usr/local/bin/wp
-if [ ! -f $WP_CLI ]; then
-  cd /usr/local/bin
-  /usr/bin/curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-  mv wp-cli.phar /usr/local/bin/wp
+cd /usr/local/bin
+/usr/bin/curl -fO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+if [ -f wp-cli.phar ] ; then
+  mv -f wp-cli.phar /usr/local/bin/wp
   chmod +x /usr/local/bin/wp
 fi
 

--- a/initial.wp-setup-woo.sh
+++ b/initial.wp-setup-woo.sh
@@ -76,8 +76,9 @@ if [ -f /etc/nginx/conf.d/default.backend.conf ]; then
   /bin/rm -f /etc/nginx/conf.d/default.backend.conf
 fi
 
-/usr/bin/git -C /opt/local/chef-repo/ pull origin master
-/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH}
+# /usr/bin/git -C /opt/local/chef-repo/ pull origin master
+/usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH} || \
+  /usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull mirror ${AMIMOTO_BRANCH}
 /usr/bin/chef-solo -c /opt/local/solo.rb -j /opt/local/amimoto.json
 if [ ! -f /etc/nginx/nginx.conf ]; then
   /usr/bin/chef-solo -o amimoto::nginx -c /opt/local/solo.rb -j /opt/local/amimoto.json

--- a/initial.wp-setup-woo.sh
+++ b/initial.wp-setup-woo.sh
@@ -91,7 +91,7 @@ fi
 /usr/sbin/update-motd
 
 cd /tmp
-/usr/bin/git clone git://github.com/megumiteam/amimoto.git
+/usr/bin/git clone git://github.com/megumiteam/amimoto.git || /usr/bin/git clone http://repos.amimoto-ami.com/amimoto.git
 
 #CF_PATTERN=`/usr/bin/curl -s https://raw.githubusercontent.com/megumiteam/amimoto/master/cf_patern_check.php | /usr/bin/php`
 CF_PATTERN=`/usr/bin/php /tmp/amimoto/cf_patern_check.php`
@@ -132,10 +132,10 @@ fi
 /sbin/service monit start
 
 WP_CLI=/usr/local/bin/wp
-if [ ! -f $WP_CLI ]; then
-  cd /usr/local/bin
-  /usr/bin/curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-  mv wp-cli.phar /usr/local/bin/wp
+cd /usr/local/bin
+/usr/bin/curl -fO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+if [ -f wp-cli.phar ] ; then
+  mv -f wp-cli.phar /usr/local/bin/wp
   chmod +x /usr/local/bin/wp
 fi
 

--- a/initial.wp-setup.sh
+++ b/initial.wp-setup.sh
@@ -86,7 +86,7 @@ fi
 /usr/sbin/update-motd
 
 cd /tmp
-/usr/bin/git clone git://github.com/megumiteam/amimoto.git
+/usr/bin/git clone git://github.com/megumiteam/amimoto.git || /usr/bin/git clone http://repos.amimoto-ami.com/amimoto.git
 
 #CF_PATTERN=`/usr/bin/curl -s https://raw.githubusercontent.com/megumiteam/amimoto/master/cf_patern_check.php | /usr/bin/php`
 CF_PATTERN=`/usr/bin/php /tmp/amimoto/cf_patern_check.php`
@@ -141,10 +141,10 @@ fi
 /sbin/service monit start
 
 WP_CLI=/usr/local/bin/wp
-if [ ! -f $WP_CLI ]; then
-  cd /usr/local/bin
-  /usr/bin/curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-  mv wp-cli.phar /usr/local/bin/wp
+cd /usr/local/bin
+/usr/bin/curl -fO https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+if [ -f wp-cli.phar ] ; then
+  mv -f wp-cli.phar /usr/local/bin/wp
   chmod +x /usr/local/bin/wp
 fi
 

--- a/initial.wp-setup.sh
+++ b/initial.wp-setup.sh
@@ -68,7 +68,8 @@ if [ "t1.micro" != "${INSTANCETYPE}" ]; then
     /usr/sbin/alternatives --set python /usr/bin/python2.6
   fi
   #/usr/bin/git -C /opt/local/chef-repo/ pull origin master
-  /usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH}
+  /usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull origin ${AMIMOTO_BRANCH} || \
+    /usr/bin/git -C /opt/local/chef-repo/cookbooks/amimoto/ pull mirror ${AMIMOTO_BRANCH}
   /usr/bin/chef-solo -c /opt/local/solo.rb -j /opt/local/amimoto.json
   if [ ! -f /etc/nginx/nginx.conf ]; then
     /usr/bin/chef-solo -o amimoto::nginx -c /opt/local/solo.rb -j /opt/local/amimoto.json


### PR DESCRIPTION
次の2つの処理を入れました。
- git関連のclone/fetchを github => s3 の順でFailBackする
- wp-cliは最新が取れたら取る、取れなかったらAMI作成時に仕込んである(予定の)当時の最新バージョンを使う
