### PR TITLE
use mirror only nginx

### DIFF
--- a/attributes/yum_repo.rb
+++ b/attributes/yum_repo.rb
@@ -1,4 +1,4 @@
-default[:yum][:repo][:amimoto_repo] = false
+default[:yum][:repo][:amimoto_repo] = true
 default[:yum][:repo][:remi][:php][:mirrorlist] = 'http://rpms.famillecollet.com/enterprise/6/remi/mirror'
 default[:yum][:repo][:remi][:php][:baseurl] = 'http://rpms.famillecollet.com/enterprise/6/remi/$basearch/'
 default[:yum][:repo][:remi][:php55][:mirrorlist] = 'http://rpms.famillecollet.com/enterprise/6/php55/mirror'
@@ -10,9 +10,9 @@ default[:yum][:repo][:remi][:php70][:baseurl] = 'http://rpms.famillecollet.com/e
 default[:yum][:repo][:nginx][:baseurl] = 'https://packagecloud.io/amimoto-nginx-mainline/main/el/6/$basearch'
 
 if node[:yum][:repo][:amimoto_repo]
-  default[:yum][:repo][:remi][:php][:baseurl] = 'http://repos.amimoto-ami.com/enterprise/6/remi/x86_64/'
-  default[:yum][:repo][:remi][:php55][:baseurl] = 'http://repos.amimoto-ami.com/enterprise/6/remi-php55/x86_64/'
-  default[:yum][:repo][:remi][:php56][:baseurl] = 'http://repos.amimoto-ami.com/enterprise/6/remi-php56/x86_64/'
-  default[:yum][:repo][:remi][:php70][:baseurl] = 'http://repos.amimoto-ami.com/enterprise/6/remi-php70/x86_64/'
+#  default[:yum][:repo][:remi][:php][:baseurl] = 'http://repos.amimoto-ami.com/enterprise/6/remi/x86_64/'
+#  default[:yum][:repo][:remi][:php55][:baseurl] = 'http://repos.amimoto-ami.com/enterprise/6/remi-php55/x86_64/'
+#  default[:yum][:repo][:remi][:php56][:baseurl] = 'http://repos.amimoto-ami.com/enterprise/6/remi-php56/x86_64/'
+#  default[:yum][:repo][:remi][:php70][:baseurl] = 'http://repos.amimoto-ami.com/enterprise/6/remi-php70/x86_64/'
   default[:yum][:repo][:nginx][:baseurl] = 'http://repos.amimoto-ami.com/enterprise/6/amimoto-nginx-mainline/$basearch'
 end


### PR DESCRIPTION
下記エラーへの対策で、nginxはミラー、remiは一旦originを参照する。

```
https://packagecloud.io/amimoto-nginx-mainline/main/el/6/x86_64/repodata/repomd.xml:
  [Errno 14] PYCURL ERROR 22 - "The requested URL returned error: 429 Too Many Requests"
```
