### PR TITLE
replace old style node attribute dot getter to synbol style.

### DIFF
--- a/recipes/nfs_client.rb
+++ b/recipes/nfs_client.rb
@@ -1,5 +1,5 @@
 cfn = JSON.load(::File.read('/opt/aws/cloud_formation.json'))
-describe_cmd = "/usr/bin/aws ec2 describe-instances --instance-id #{cfn['nfs']['server']['instance-id']} --region #{node.ec2[:placement_availability_zone].chop} "
+describe_cmd = "/usr/bin/aws ec2 describe-instances --instance-id #{cfn['nfs']['server']['instance-id']} --region #{node[:ec2][:placement_availability_zone].chop} "
 masterserver = JSON.load(`#{describe_cmd}`)
 master_ip = masterserver['Reservations'].first['Instances'].first["PrivateIpAddress"]
 

--- a/templates/default/cfn/nfs_client.rb.erb
+++ b/templates/default/cfn/nfs_client.rb.erb
@@ -1,5 +1,5 @@
 cfn = JSON.load(::File.read('/opt/aws/cloud_formation.json'))
-describe_cmd = "/usr/bin/aws ec2 describe-instances --instance-id #{cfn['nfs']['server']['instance-id']} --region #{node.ec2[:placement_availability_zone].chop} "
+describe_cmd = "/usr/bin/aws ec2 describe-instances --instance-id #{cfn['nfs']['server']['instance-id']} --region #{node[:ec2][:placement_availability_zone].chop} "
 masterserver = JSON.load(`#{describe_cmd}`)
 master_ip = masterserver['Reservations'].first['Instances'].first["PrivateIpAddress"]
 

--- a/templates/default/hhvm/server.ini.erb
+++ b/templates/default/hhvm/server.ini.erb
@@ -18,7 +18,7 @@ hhvm.repo.central.path = /tmp/.hhvm.hhbc
 hhvm.server.file_socket = <%= @file_socket %>
 
 ;;; please update 2 * number of CPUs
-hhvm.server.thread_count = <%= node.cpu.total * 2 %>
+hhvm.server.thread_count = <%= node[:cpu][:total] * 2 %>
 
 ; server mode options
 hhvm.server.type = fastcgi


### PR DESCRIPTION
Node Attributeを取得する`node.foo.bar`の旧スタイルを`node[:foo][:bar]` に変更します。

`node.override`や`node.run_state`はもともとあるメソッドなので逆に変更してはダメ系です。