### PR TITLE
support m4 instances

### DIFF
--- a/attributes/05_middlewares.rb
+++ b/attributes/05_middlewares.rb
@@ -170,6 +170,108 @@ when "m3.2xlarge"
   default[:mysql][:config][:tmp_table_size]  = '512M'
   default[:mysql][:config][:max_connections] = '256'
   default[:mysql][:config][:thread_cache] = '256'
+when "m4.large"
+  ## Nginx
+  default[:nginx][:config][:worker_processes] = '2'
+
+  ## PHP
+  default[:php][:config][:max_children] = '20'
+  default[:php][:config][:start_servers] = '4'
+  default[:php][:config][:min_spare_servers] = '4'
+  default[:php][:config][:max_spare_servers] = '16'
+  default[:php][:config][:max_requests] = '200'
+
+  ## MySQL
+  default[:mysql][:config][:innodb_buffer_pool_size] = '256M'
+  default[:mysql][:config][:query_cache_size] = '256M'
+  default[:mysql][:config][:tmp_table_size]  = '256M'
+  default[:mysql][:config][:max_connections] = '256'
+  default[:mysql][:config][:thread_cache] = '256'
+when "m4.xlarge"
+  ## Nginx
+  default[:nginx][:config][:worker_processes] = '4'
+
+  ## PHP
+  default[:php][:config][:max_children] = '35'
+  default[:php][:config][:start_servers] = '10'
+  default[:php][:config][:min_spare_servers] = '10'
+  default[:php][:config][:max_spare_servers] = '25'
+  default[:php][:config][:max_requests] = '200'
+
+  ## MySQL
+  default[:mysql][:config][:innodb_buffer_pool_size] = '512M'
+  default[:mysql][:config][:query_cache_size] = '512M'
+  default[:mysql][:config][:tmp_table_size]  = '512M'
+  default[:mysql][:config][:max_connections] = '256'
+  default[:mysql][:config][:thread_cache] = '256'
+when "m4.2xlarge"
+  ## Nginx
+  default[:nginx][:config][:worker_processes] = '8'
+
+  ## PHP
+  default[:php][:config][:max_children] = '35'
+  default[:php][:config][:start_servers] = '10'
+  default[:php][:config][:min_spare_servers] = '10'
+  default[:php][:config][:max_spare_servers] = '25'
+  default[:php][:config][:max_requests] = '200'
+
+  ## MySQL
+  default[:mysql][:config][:innodb_buffer_pool_size] = '512M'
+  default[:mysql][:config][:query_cache_size] = '512M'
+  default[:mysql][:config][:tmp_table_size]  = '512M'
+  default[:mysql][:config][:max_connections] = '256'
+  default[:mysql][:config][:thread_cache] = '256'
+when "m4.4xlarge"
+  ## Nginx
+  default[:nginx][:config][:worker_processes] = '16'
+
+  ## PHP
+  default[:php][:config][:max_children] = '50'
+  default[:php][:config][:start_servers] = '10'
+  default[:php][:config][:min_spare_servers] = '10'
+  default[:php][:config][:max_spare_servers] = '25'
+  default[:php][:config][:max_requests] = '200'
+
+  ## MySQL
+  default[:mysql][:config][:innodb_buffer_pool_size] = '512M'
+  default[:mysql][:config][:query_cache_size] = '512M'
+  default[:mysql][:config][:tmp_table_size]  = '512M'
+  default[:mysql][:config][:max_connections] = '256'
+  default[:mysql][:config][:thread_cache] = '256'
+when "m4.10xlarge"
+  ## Nginx
+  default[:nginx][:config][:worker_processes] = '40'
+
+  ## PHP
+  default[:php][:config][:max_children] = '50'
+  default[:php][:config][:start_servers] = '10'
+  default[:php][:config][:min_spare_servers] = '10'
+  default[:php][:config][:max_spare_servers] = '25'
+  default[:php][:config][:max_requests] = '200'
+
+  ## MySQL
+  default[:mysql][:config][:innodb_buffer_pool_size] = '512M'
+  default[:mysql][:config][:query_cache_size] = '512M'
+  default[:mysql][:config][:tmp_table_size]  = '512M'
+  default[:mysql][:config][:max_connections] = '256'
+  default[:mysql][:config][:thread_cache] = '256'
+when "m4.16xlarge"
+  ## Nginx
+  default[:nginx][:config][:worker_processes] = '64'
+
+  ## PHP
+  default[:php][:config][:max_children] = '50'
+  default[:php][:config][:start_servers] = '10'
+  default[:php][:config][:min_spare_servers] = '10'
+  default[:php][:config][:max_spare_servers] = '25'
+  default[:php][:config][:max_requests] = '200'
+
+  ## MySQL
+  default[:mysql][:config][:innodb_buffer_pool_size] = '512M'
+  default[:mysql][:config][:query_cache_size] = '512M'
+  default[:mysql][:config][:tmp_table_size]  = '512M'
+  default[:mysql][:config][:max_connections] = '256'
+  default[:mysql][:config][:thread_cache] = '256'
 when "m1.small"
   ## Nginx
   default[:nginx][:config][:worker_processes] = '1'


### PR DESCRIPTION

|Model|vCPU|Mem (GiB)|SSD Storage (GB)|Dedicated EBS Bandwidth (Mbps)|Based Model|
|:--|:--|:--|:--|:--|:--|
|m4.large|2|8|EBS-only|450|m3.large|
|m4.xlarge|4|16|EBS-only|750|m3.xlarge|
|m4.2xlarge|8|32|EBS-only|1,000|m3.2xlarge|
|m4.4xlarge|16|64|EBS-only|2,000|m2.4xlarge|
|m4.10xlarge|40|160|EBS-only|4,000|m2.4xlarge|
|m4.16xlarge|64|256|EBS-only|10,000|m2.4xlarge|