### PR TITLE
check before unzip

### DIFF
--- a/providers/wpplugin.rb
+++ b/providers/wpplugin.rb
@@ -4,7 +4,7 @@ action :install do
   install_path = "#{::File.join(new_resource.install_path,'/wp-content/plugins/',new_resource.plugin_name)}"
   release_file = "#{new_resource.plugin_name}.zip"
   work_file    = "#{::File.join('/tmp/.cache/wpplugins/',release_file)}"
-  release_url  = "http://downloads.wordpress.org/plugin/#{new_resource.plugin_name}.zip"
+  release_url  = "https://downloads.wordpress.org/plugin/#{new_resource.plugin_name}.zip"
 
   directory '/tmp/.cache/wpplugins/' do
     recursive true
@@ -45,6 +45,7 @@ action :install do
     user "root"
     umask '0002'
     cwd "/tmp"
+    only_if "test -f #{work_file}"
     code <<-EOH
       /usr/bin/unzip #{work_file} -d #{plugins_path}
       chown -R #{node[:nginx][:config][:user]}:#{node[:nginx][:config][:group]} #{install_path}

--- a/providers/wptheme.rb
+++ b/providers/wptheme.rb
@@ -45,6 +45,7 @@ action :install do
     user "root"
     umask '0002'
     cwd "/tmp"
+    only_if "test -f #{work_file}"
     code <<-EOH
       /usr/bin/unzip #{work_file} -d #{themes_path}
       chown -R #{node[:nginx][:config][:user]}:#{node[:nginx][:config][:group]} #{install_path}

--- a/providers/wptheme.rb
+++ b/providers/wptheme.rb
@@ -4,7 +4,7 @@ action :install do
   install_path = "#{::File.join(new_resource.install_path,'/wp-content/themes/',new_resource.theme_name)}"
   release_file = "#{new_resource.theme_name}.zip"
   work_file    = "#{::File.join('/tmp/.cache/wpthemes/',release_file)}"
-  release_url  = "http://downloads.wordpress.org/theme/#{new_resource.theme_name}.zip"
+  release_url  = "https://downloads.wordpress.org/theme/#{new_resource.theme_name}.zip"
 
   directory '/tmp/.cache/wpthemes/' do
     recursive true

--- a/providers/wptheme.rb
+++ b/providers/wptheme.rb
@@ -49,8 +49,8 @@ action :install do
     code <<-EOH
       /usr/bin/unzip #{work_file} -d #{themes_path}
       chown -R #{node[:nginx][:config][:user]}:#{node[:nginx][:config][:group]} #{install_path}
-      find #{install_path} -type d -exec chmod 775 {} \;
-      find #{install_path} -type f -exec chmod 664 {} \;
+      find #{install_path} -type d -exec chmod 775 {} \\;
+      find #{install_path} -type f -exec chmod 664 {} \\;
     EOH
   end
 end


### PR DESCRIPTION
remote_fileの前のdirectoryが `bash "wp-theme-unpack"`を呼んじゃうので、対象が存在する場合のみにする。