### PR TITLE
Remove protect /wp-includes/.*\.php$

### DIFF
--- a/templates/default/nginx/drop.erb
+++ b/templates/default/nginx/drop.erb
@@ -6,7 +6,6 @@ location /.well-known { auth_basic off; allow all; break; }
 
 # Protect System Files
 location ~ /\.(?!well-known) { deny all; access_log off; }
-location ~* /wp-includes/.*\.php$ { access_log off; return 404; }
 location ~* /wp-admin/includes/.*\.php$ { access_log off; return 404; }
 location ~* /wp-content/themes/.*/index\.php$ { access_log off; return 404; }
 location ~* /wp-content/languages/.*$ { access_log off; return 404; }


### PR DESCRIPTION
#90 

Gutenberg need to access `/wp-includes/js/tinymce/wp-tinymce.php`
So remove protect `.php` in `wp-includes` .