### PR TITLE
Apply gzip to wp-json

### DIFF
--- a/templates/default/nginx/nginx.conf.erb
+++ b/templates/default/nginx/nginx.conf.erb
@@ -62,6 +62,7 @@ http {
                       application/xml
                       application/rss+xml
                       application/atom_xml
+                      application/json
                       application/javascript
                       application/x-javascript
                       application/x-httpd-php;


### PR DESCRIPTION
The content below `/wp-json` is delivered with `content-type: application/json; charset = UTF-8`.

Apply gzip to those contents as well.